### PR TITLE
Corrected typo when reverting release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,7 +3,6 @@
 
 name-template: v$RESOLVED_VERSION
 tag-template: v$RESOLVED_VERSION
-commitish: refs/heads/main
 template: >
   ## What Changed 🚀
 


### PR DESCRIPTION
For some reason, commitish was not removed. This may be an oversight on my side.