### PR TITLE
Fixed missed pointings in summary tables

### DIFF
--- a/Apo_Phot.ipynb
+++ b/Apo_Phot.ipynb
@@ -120,7 +120,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb5abc37-64c9-4958-ad0f-8234cdcc751c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print(\"Defining user variables...\")\n",
@@ -275,7 +277,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a45020e5-78c4-42f9-8e7b-b5e3b7dbe765",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print(\"Defining functions...\")\n",
@@ -1533,7 +1537,9 @@
     "    photTable = tbl.QTable(photTableTemp[\"ID\", \"RA\", \"Dec\"])\n",
     "    # Start averaging columns\n",
     "    for match in tqdm(tempMatch, desc=\"Averaging pointings\"):\n",
-    "        tempCols = fnmatch.filter(tempNames, f\"{match}_*\")\n",
+    "        tempCols = fnmatch.filter(tempNames, f\"{match}[! ]*\")\n",
+    "        if len(tempCols) != tempCountsVar[-1]:\n",
+    "            tempCols += [f\"{match}\"]\n",
     "        tempAverage = []\n",
     "        for col in tempCols:\n",
     "            tempCol = photTableTemp[col].copy()\n",
@@ -1572,11 +1578,30 @@
     "                photTable.rename_column(col, f\"{col.split()[0]} Error\")\n",
     "            else:\n",
     "                photTable.remove_column(col)\n",
+    "    colNames = photTable.colnames\n",
+    "    fluxCols = fnmatch.filter(colNames, \"* Flux\")\n",
+    "    errCols = fnmatch.filter(colNames, \"* Error\")\n",
+    "    photTable.add_column(0, name=\"Total High SNR Bands (5 Sigma)\")\n",
+    "    for fluxCol, errCol in tqdm(list(zip(fluxCols,errCols))):\n",
+    "        sNRCount = np.where(photTable[fluxCol]/photTable[errCol] >= 5.0, 1, 0)\n",
+    "        photTable[\"Total High SNR Bands (5 Sigma)\"] += sNRCount\n",
     "    photTable.write(f\"{WorkDir}/Apo_Phot/{Proj_Name}/summary.fits\", overwrite=True)\n",
     "    return\n",
     "\n",
     "\n",
     "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85ec7610-0caa-4895-b497-9d3a458b6c10",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "CleanOutput()"
    ]
   },
   {
@@ -2583,7 +2608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.6"
   },
   "toc-autonumbering": true,
   "toc-showcode": false,


### PR DESCRIPTION
In the case of an odd number of pointings, AstroPy would not add a
suffix to the final merged dataset. The for loop averaging together
the results would then ignore the final pointing. This has been fixed.
